### PR TITLE
Fix publish workflows :rocket: 

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Compile
         run: yarn build
 
+      - name: Lint
+        run: yarn run lint
+
       - name: Test
         run: yarn test
 
@@ -48,9 +51,6 @@ jobs:
           node-version: 18
           registry-url: https://npm.pkg.github.com/
 
-      - name: Test
-        run: yarn test
-
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -67,9 +67,6 @@ jobs:
         with:
           node-version: 18
           registry-url: https://registry.npmjs.org/
-
-      - name: Test
-        run: yarn test
 
       - run: npm publish
         env:


### PR DESCRIPTION
```sh
Run yarn test
Usage Error: Couldn't find the node_modules state file - running an install might help (findPackageLocation)

$ yarn run [--inspect] [--inspect-brk] [-T,--top-level] [-B,--binaries-only] <scriptName> ...
Error: Process completed with exit code 1.
```