### PR TITLE
Remove `type: module` from `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "update-snapshots": "vitest run --update",
     "all": "yarn run build && yarn run format && yarn run lint && yarn test"
   },
-  "type": "module",
   "packageManager": "yarn@4.1.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
```js
ReferenceError: require is not defined in ES module scope, you can use import instead
This file is being treated as an ES module because it has a '.js' file extension and '/home/runner/work/_actions/jamacku/testing-farm-as-github-action/post/dist/package.json' contains "type": "module". To treat it as a CommonJS script, rename it to use the '.cjs' file extension.
    at eval (eval at 9362 (file:///home/runner/work/_actions/jamacku/testing-farm-as-github-action/post/node_modules/@vercel/ncc/dist/ncc/@@notfound.js:1:1), <anonymous>:1:1)
    at Object.9362 (file:///home/runner/work/_actions/jamacku/testing-farm-as-github-action/post/node_modules/@vercel/ncc/dist/ncc/@@notfound.js:1:1)
    at __nccwpck_require__ (file:///home/runner/work/_actions/jamacku/testing-farm-as-github-action/post/webpack/bootstrap:21:1)
    at Object.6474 (file:///home/runner/work/_actions/jamacku/testing-farm-as-github-action/post/dist/index.js:36285:63)
    at __nccwpck_require__ (file:///home/runner/work/_actions/jamacku/testing-farm-as-github-action/post/webpack/bootstrap:21:1)
    at Object.2768 (file:///home/runner/work/_actions/jamacku/testing-farm-as-github-action/post/dist/index.js:31569:12)
    at __nccwpck_require__ (file:///home/runner/work/_actions/jamacku/testing-farm-as-github-action/post/webpack/bootstrap:21:1)
    at file:///home/runner/work/_actions/jamacku/testing-farm-as-github-action/post/dist/index.js:35883:65
    at Function.__nccwpck_require__.a (file:///home/runner/work/_actions/jamacku/testing-farm-as-github-action/post/webpack/runtime/async module:49:1)
    at Object.399 (file:///home/runner/work/_actions/jamacku/testing-farm-as-github-action/post/dist/index.js:35878:21)
```