### PR TITLE
Add `unsafeNewRequest(unknown): unknown` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ const request = { /* https://api.dev.testing-farm.io/redoc#operation/request_a_n
 
 const response: NewRequestResponse = await api.newRequest(request);
 const response: unknown = await api.newRequest(request, false);
-const response: unknown = await.unsafeNewRequest(request);
+const response: unknown = await api.unsafeNewRequest(request /* unknown type */);
 ```
 
 ### Test Request Details

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ const request = { /* https://api.dev.testing-farm.io/redoc#operation/request_a_n
 
 const response: NewRequestResponse = await api.newRequest(request);
 const response: unknown = await api.newRequest(request, false);
+const response: unknown = await.unsafeNewRequest(request);
 ```
 
 ### Test Request Details

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,9 +79,7 @@ export default class TestingFarmAPI {
   }
 
   async unsafeNewRequest(request: unknown): Promise<unknown> {
-    return newRequestResponseSchema.parse(
-      await this.link.post('requests', request)
-    );
+    return await this.link.post('requests', request);
   }
 
   async requestDetails(requestId: string): Promise<Request>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,6 +78,12 @@ export default class TestingFarmAPI {
     );
   }
 
+  async unsafeNewRequest(request: unknown): Promise<unknown> {
+    return newRequestResponseSchema.parse(
+      await this.link.post('requests', request)
+    );
+  }
+
   async requestDetails(requestId: string): Promise<Request>;
   async requestDetails(requestId: string, strict: boolean): Promise<unknown>;
   async requestDetails(requestId: string, strict?: boolean): Promise<unknown> {

--- a/test/integration/new-request.test.ts
+++ b/test/integration/new-request.test.ts
@@ -34,5 +34,9 @@ describe('Test Testing Farm POST /requests', () => {
         },
       ],
     });
+
+    await expect(response).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[Error: {"message":"Test section is empty or test type is wrong."}]`
+    );
   });
 });

--- a/test/integration/new-request.test.ts
+++ b/test/integration/new-request.test.ts
@@ -22,4 +22,17 @@ describe('Test Testing Farm POST /requests', () => {
       `[Error: {"message":"Test section is empty or test type is wrong."}]`
     );
   });
+  test('unsafe request', async () => {
+    const api = new TestingFarmAPI('https://api.dev.testing-farm.io/v0.1');
+
+    const response = api.unsafeNewRequest({
+      api_key: 'api_key',
+      test: {},
+      environments: [
+        {
+          hardware: '{"something":"foobar"}',
+        },
+      ],
+    });
+  });
 });


### PR DESCRIPTION
This pull request adds support for hardware specifications, which are allowed by testing farm,
but will not be checked by TestingFarmAsGithubAction. See https://github.com/sclorg/testing-farm-as-github-action/pull/146