### PR TITLE
fix: allow os field to be null in environment schema

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -40,7 +40,8 @@ const environmentSchema = z.object({
     .object({
       compose: z.string().min(1),
     })
-    .optional(),
+    .optional()
+    .nullable(),
   pool: z.string().min(1).optional().nullable(),
   variables: z.record(z.string()).optional(),
   secrets: z.record(z.string()).optional(),

--- a/test/integration/new-request.test.ts
+++ b/test/integration/new-request.test.ts
@@ -39,4 +39,27 @@ describe('Test Testing Farm POST /requests', () => {
       `[Error: {"message":"Test section is empty or test type is wrong."}]`
     );
   });
+
+  test('request with os null', async () => {
+    const api = new TestingFarmAPI('https://api.dev.testing-farm.io/v0.1');
+
+    const response = api.newRequest({
+      api_key: 'api_key',
+      test: {
+        fmf: {
+          url: 'https://github.com/example/repo',
+        },
+      },
+      environments: [
+        {
+          arch: 'x86_64',
+          os: null,
+        },
+      ],
+    });
+
+    await expect(response).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[Error: {"message":"Not authorized to perform this action"}]`
+    );
+  });
 });

--- a/test/unit/schema.test.ts
+++ b/test/unit/schema.test.ts
@@ -1,0 +1,86 @@
+import { describe, test, expect } from 'vitest';
+
+import { newRequestSchema } from '../../src/schema';
+
+describe('Schema validation', () => {
+  describe('environment schema', () => {
+    test('should allow os field to be null', () => {
+      const validRequest = {
+        test: {
+          fmf: {
+            url: 'https://github.com/example/repo',
+          },
+        },
+        environments: [
+          {
+            arch: 'x86_64',
+            os: null,
+          },
+        ],
+      };
+
+      const result = newRequestSchema.safeParse(validRequest);
+      expect(result.success).toBe(true);
+    });
+
+    test('should allow os field to be undefined', () => {
+      const validRequest = {
+        test: {
+          fmf: {
+            url: 'https://github.com/example/repo',
+          },
+        },
+        environments: [
+          {
+            arch: 'x86_64',
+          },
+        ],
+      };
+
+      const result = newRequestSchema.safeParse(validRequest);
+      expect(result.success).toBe(true);
+    });
+
+    test('should allow os field to be an object', () => {
+      const validRequest = {
+        test: {
+          fmf: {
+            url: 'https://github.com/example/repo',
+          },
+        },
+        environments: [
+          {
+            arch: 'x86_64',
+            os: {
+              compose: 'Fedora-latest',
+            },
+          },
+        ],
+      };
+
+      const result = newRequestSchema.safeParse(validRequest);
+      expect(result.success).toBe(true);
+    });
+
+    test('should reject invalid os object', () => {
+      const invalidRequest = {
+        test: {
+          fmf: {
+            url: 'https://github.com/example/repo',
+          },
+        },
+        environments: [
+          {
+            arch: 'x86_64',
+            os: {
+              compose: '',
+            },
+          },
+        ],
+      };
+
+      const result = newRequestSchema.safeParse(invalidRequest);
+      expect(result.success).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
The os field in environmentSchema now accepts null values to prevent validation errors when os is explicitly set to null.

This is needed for https://github.com/sclorg/testing-farm-as-github-action/pull/298

Assisted-by: Claude Code

Resolves https://issues.redhat.com/browse/TFT-3614